### PR TITLE
custom html title for `Handout` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python
 __pycache__/
+.pytest_cache/
 *.py[cod]
 
 # Pip

--- a/handout/handout.py
+++ b/handout/handout.py
@@ -10,7 +10,7 @@ from handout import blocks
 
 class Handout(object):
 
-  def __init__(self, directory, title="Handout"):
+  def __init__(self, directory, title='Handout'):
     self._directory = os.path.expanduser(directory)
     os.makedirs(self._directory, exist_ok=True)
     self._title = title

--- a/handout/handout.py
+++ b/handout/handout.py
@@ -10,9 +10,10 @@ from handout import blocks
 
 class Handout(object):
 
-  def __init__(self, directory):
+  def __init__(self, directory, title="Handout"):
     self._directory = os.path.expanduser(directory)
     os.makedirs(self._directory, exist_ok=True)
+    self._title = title
     self._blocks = collections.defaultdict(list)
     self._pending = []
     self._logger = logging.getLogger('handout')
@@ -113,7 +114,7 @@ class Handout(object):
     content.append(blocks.Html([
         '<html>',
         '<head>',
-        '<title>Handout</title>',
+        '<title>{}</title>'.format(self._title),
         '<link rel="stylesheet" href="style.css">',
         '<link rel="stylesheet" href="highlight.css">',
         '<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">',

--- a/handout/tests/test_handout.py
+++ b/handout/tests/test_handout.py
@@ -1,7 +1,5 @@
-import tempfile
+import handout
 
-from handout import Handout
-
-def test_handout_on_title_arg_inserts_title():
-    h = Handout(directory=tempfile.mkdtemp(), title="This string")._generate(source="")   
-    assert "<title>This string</title>" in h
+def test_handout_on_title_arg_inserts_title(tmp_path):
+    output = handout.Handout(directory=tmp_path, title='This string')._generate(source='')   
+    assert '<title>This string</title>' in output

--- a/handout/tests/test_handout.py
+++ b/handout/tests/test_handout.py
@@ -1,0 +1,7 @@
+import tempfile
+
+from handout import Handout
+
+def test_handout_on_title_arg_inserts_title():
+    h = Handout(directory=tempfile.mkdtemp(), title="This string")._generate(source="")   
+    assert "<title>This string</title>" in h


### PR DESCRIPTION
Added argument for custom html document title in `Handout` class  and proposed unit test layout. 