### PR TITLE
Accept pathlib.Path filenames and forward **imageio_kwargs

### DIFF
--- a/handout/handout.py
+++ b/handout/handout.py
@@ -53,7 +53,7 @@ class Handout(object):
       message = message[:-1]
     self._logger.info(message)
 
-  def add_image(self, image, format='png', width=None):
+  def add_image(self, image, format='png', width=None, **imageio_args):
     if isinstance(image, str):
       filename = image
     else:
@@ -65,13 +65,13 @@ class Handout(object):
     self._pending.append(block)
     self._num_images += 1
 
-  def add_video(self, video, format='gif', fps=30, width=None):
+  def add_video(self, video, format='gif', fps=30, width=None, **imageio_args):
     if isinstance(video, str):
       filename = video
     else:
       import imageio
       filename = 'video-{}.{}'.format(self._num_videos, format)
-      imageio.mimsave(self._directory / filename, video, fps=fps)
+      imageio.mimsave(self._directory / filename, video, fps=fps, **imageio_args)
       self._logger.info('Saved video: {}'.format(filename))
     if filename.endswith('.gif'):
       block = blocks.Image(filename, width)

--- a/handout/handout.py
+++ b/handout/handout.py
@@ -54,8 +54,8 @@ class Handout(object):
     self._logger.info(message)
 
   def add_image(self, image, format='png', width=None, **imageio_args):
-    if isinstance(image, str):
-      filename = image
+    if isinstance(image, str) or isinstance(image, pathlib.Path):
+      filename = str(video)
     else:
       import imageio
       filename = 'image-{}.{}'.format(self._num_images, format)
@@ -66,8 +66,8 @@ class Handout(object):
     self._num_images += 1
 
   def add_video(self, video, format='gif', fps=30, width=None, **imageio_args):
-    if isinstance(video, str):
-      filename = video
+    if isinstance(video, str) or isinstance(video, pathlib.Path):
+      filename = str(video)
     else:
       import imageio
       filename = 'video-{}.{}'.format(self._num_videos, format)


### PR DESCRIPTION
I've made two improvements to the code for adding images and videos:
- Support for `pathlib.Path` (previously a crash would occur if you provide a `pathlib.Path` to a video on disk)
- Support for arbitrary arguments to `imageio` functions (in some cases I've had to use custom values for `macro_block_size`; with this version you can input arbitrary such `imageio` arguments into `add_image` and `add_video`).