### PR TITLE
[FIX] Fix TypeError: invalid file: PosixPath

### DIFF
--- a/handout/handout.py
+++ b/handout/handout.py
@@ -99,7 +99,7 @@ class Handout(object):
     self._pending = []
     output = self._generate(self._source_text)
     filename = self._directory / 'index.html'
-    with open(filename, 'w') as f:
+    with open(str(filename), 'w') as f:
       f.write(output)
     datadir = pathlib.Path(__file__).parent / 'data'
     for source in datadir.glob('**/*'):
@@ -107,7 +107,7 @@ class Handout(object):
       if source.is_dir() or target.exists():
         continue
       target.parent.mkdir(exist_ok=True)
-      shutil.copyfile(source, target)
+      shutil.copyfile(str(source), str(target))
     self._logger.info("Handout written to: {}".format(filename))
 
   def _generate(self, source):


### PR DESCRIPTION
Hello,

When using Ubuntu 18.04 and Python 3.5.6, the following error was arises when calling show function:

```
  File "./app.py", line 6, in <module>
    report.build_report()
  File "/home/jvicente/myreport/report_class.py", line 66, in build_report
    doc.show()
  File "/home/jvicente/anaconda2/envs/qcreport/lib/python3.5/site-packages/handout/handout.py", line 102, in show
    with open(filename, 'w') as f:
TypeError: invalid file: PosixPath('output/index.html')
```

With this fixed, that problem is solved.